### PR TITLE
Simplify summary table

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,11 +49,8 @@ layout: default
       <tr>
         <th>New/Updated</th>
         <th>Country</th>
-        <th>Law/Legislation Name</th>
         <th>Type (Policy, law, legislation, etc.)</th>
         <th>Scope</th>
-        <th>Web Only</th>
-        <th>WCAG Version Used</th>
         <th>Status</th>
       </tr>
       {% for policy in site.policies %}
@@ -61,11 +58,8 @@ layout: default
       <tr data-updated="{{policy.updated}}">
         <td>{{p.updated}}</td>
         <td><a href="#x{{policy.title | slugify }}">{{policy.title}}</a> {%if policy.native_title%}({{policy.native_title}}){%endif%}</td>
-        <th><a href="{{p.url}}">{{p.title}}</a></th>
         <td>{{p.type}}</td>
         <td>{{p.scope}}</td>
-        <td>{{p.webonly}}</td>
-        <td>{{p.wcagver}}</td>
         <td>{{p.status}}</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
Removing law/legislation name, web only, WCAG version columns.
This will be revisited with additional thoughts on filtering/sorting
similar to Tools or QuickRef pages and ongoing discussions.

Addresses issue #5