### PR TITLE
condensing information into one section/markdown file

### DIFF
--- a/_help/1-disclaimer.md
+++ b/_help/1-disclaimer.md
@@ -1,5 +1,0 @@
----
-title: Disclaimer
----
-
-This page provides an overview of applicable national laws and policies for web accessibility – it is _not_ comprehensive. The information provided is _not_ legal advice. If you have questions about the applicability of the links to specific situations, consult with legal authorities in the appropriate country.

--- a/_help/1-introduction.md
+++ b/_help/1-introduction.md
@@ -1,0 +1,25 @@
+---
+title: Introduction
+---
+
+The Web Policy Overview table provides a quick reference of the various laws and policies used throughout the world. Further details are available in the sections below the table.
+
+[Developing Organizational Policies on Web Accessibility](#developing) addresses issues which frequently arise when establishing policies on Web accessibility.
+
+### Disclaimer: This is <em>not legal advice</em>.
+
+This page provides an overview of applicable national laws and policies for web accessibility – it is _not_ comprehensive. The information provided is _not_ legal advice. If you have questions about the applicability of the links to specific situations, consult with legal authorities in the appropriate country.
+
+### Updates
+
+If you know of new or changed legislation, laws, or policies that are not listed here or if any corrections are needed, please let us know.
+
+<button>Start an Update (placeholder)</button>
+
+### Terms used on this page
+
+* **Law** – A law has completed the legislation process, and is put into effect as the law of the land.  
+* **Policy** – Outlines the goals of a government ministry or agency as well as the methods and principles to achieve those goals. Policies are not laws, but can lead to the development of laws.
+* **Public sector** – Includes government and government-run or owned entities, and entities that receive government funding.
+* **Private sector** – Businesses and organizations that are not part of the public sector, including non-profit organizations.
+* **WCAG derivative** - Used when a standard is based on a version of WCAG, but some requirements were excluded or modified or additional non-WCAG requirements were added.

--- a/_help/2-updates.md
+++ b/_help/2-updates.md
@@ -1,7 +1,0 @@
----
-title: Updates
----
-
-If you know of new or changed legislation, laws, or policies that are not listed here or if any corrections are needed, please let us know.
-
-<button>Start an Update (placeholder)</button>

--- a/_help/3-introduction.md
+++ b/_help/3-introduction.md
@@ -1,7 +1,0 @@
----
-title: Introduction
----
-
-The Web Policy Overview table provides a quick reference of the various laws and policies used throughout the world. Further details are available in the sections below the table.
-
-[Developing Organizational Policies on Web Accessibility](#developing) addresses issues which frequently arise when establishing policies on Web accessibility.

--- a/_help/4-terms.md
+++ b/_help/4-terms.md
@@ -1,9 +1,0 @@
----
-title: Terms used on this page
----
-
-* **Law** – A law has completed the legislation process, and is put into effect as the law of the land.  
-* **Policy** – Outlines the goals of a government ministry or agency as well as the methods and principles to achieve those goals. Policies are not laws, but can lead to the development of laws.
-* **Public sector** – Includes government and government-run or owned entities, and entities that receive government funding.
-* **Private sector** – Businesses and organizations that are not part of the public sector, including non-profit organizations.
-* **WCAG derivative** - Used when a standard is based on a version of WCAG, but some requirements were excluded or modified or additional non-WCAG requirements were added.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
   <h1>Contents</h1>
   <ul>
     {% for help in site.help %}
-      <li><a href="#x{{help.title | slugify }}" style="display:inline-block;">{{help.title}}</a></li>
+      <li><a href="#x{{help.title | slugify }}">{{help.title}}</a></li>
     {% endfor %}
     <li><a href="#xtable">Law &amp; Policy by Country - table</a></li>
     <li><a href="#xlist">Laws &amp; Policies by Country - detail</a>
@@ -27,17 +27,8 @@ layout: default
   <h1>Web Accessibility Laws &amp; Policies</h1>
 
   {% for help in site.help %}
-    {% if help.title == "Disclaimer" %}
-    <details open>
-      <summary><h2 id="x{{help.title | slugify }}">{{help.title}}: This is <em>not legal advice</em>.</h2></summary>
-      <div>
-        {{help.content}}
-      </div>
-    </details>
-    {% else %}
     <h2 id="x{{help.title | slugify }}">{{help.title}}</h2>
     {{help.content}}
-    {% endif %}
   {% endfor %}
 
 <details open>


### PR DESCRIPTION
This addresses issue #13 but it may not be what @slhenry and @maryjom
had in mind. I used h3s for the sections for disclaimer, updates, and
terms, but they aren’t styled much different visually than the h2 for
the Introduction. We may not need headings for those subsection, but I
left them in for now.