### PR TITLE
Fixed typo "endity". Fixed Web only true/false.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -14,10 +14,10 @@ layout: default
       <h2><a href="{{p.url}}">{{p.title}}</a></h2>
       <div>
         <ul>
-          <li>Responsible {%if p.ministries.size == 1%}Endity (Agency, Ministry, etc.){%else%}Entities (Agencies, Ministries, etc.){%endif%}: {% for m in p.ministries %} <a href="{{m.url}}">{{m.title}}</a>{%if forloop.last == false%}; {%endif%}{%endfor%}</li>
+          <li>Responsible {%if p.ministries.size == 1%}Entity (Agency, Ministry, etc.){%else%}Entities (Agencies, Ministries, etc.){%endif%}: {% for m in p.ministries %} <a href="{{m.url}}">{{m.title}}</a>{%if forloop.last == false%}; {%endif%}{%endfor%}</li>
           <li>Type: {{p.type}}</li>
           <li>Scope: {{p.scope}}</li>
-          <li>Web only: {{p.webonly}}</li>
+          <li>Web only: {%if p.webonly == true %}yes{% else %}no{%endif%}</li>
           <li>WCAG Version Used: {{p.wcagver}}</li>
           {%if p.standard%}
             <li>Standard: {% assign standard = site.data.standards[p.standard]%} <a href="{{standard.url}}">{{standard.title}}</a> {%if standard.desc%} – {{standard.desc}}{%endif%}</li>


### PR DESCRIPTION
Fix to text used to handle Issue #9 should be 'entity' not 'endity'.  Also Fixed country details page where web only was showing "true" or "false" instead of "yes" or "no".