### PR TITLE
Moved native country name description closer to field

### DIFF
--- a/submission.html
+++ b/submission.html
@@ -87,8 +87,7 @@ layout: default
       <h3 class="visuallyhidden">Policy to Add or Update</h3>
       <ul class="form-block-mini">
         <li class="form-row required"><label for="country">Country of policy (in English): </label><span><input id="country" name="country"></span></li>
-        <li class="form-row"><label for="native-country">Country of policy (in native language): </label><span><input id="native-country" name="native-country"></span></li>
-        <p>If known by multiple names, separate with a semicolon, e.g. Schwiz;Suisse</p>
+        <li class="form-row"><label for="native-country">Country of policy (in native language): </label><span><input name="native-country" id="native-country" type="text" value="" aria-describedby="native-countrydesc"></span></li><br><span id="native-countrydesc">If known by multiple names, separate with a semicolon, e.g. Schwiz;Suisse</span>
         <li class="form-row required"><label for="policyname">Policy name: </label><span><input name="policyname" id="policyname" type="text"  value="" required aria-required="true"></span></li>
         <li class="form-row required"><label for="policyurl">Web address (<abbr title="Universal Resource Identifier">URI</abbr>): </label><span><input name="policyurl" id="policyurl" type="text" value="" required aria-required="true"></span></li>
         <li class="form-row required"><label for="enactdate">Enacted date (format: YYYY): </label><span><input name="enactdate" id="enactdate" type="text" value="" required aria-required="true" aria-describedby="enactdesc"><br><span id="enactdesc">Enter the year the policy was enacted or "draft" if the policy is not yet finalized or enacted.</span></span></li>


### PR DESCRIPTION
Fixed markup to move the description and example for the country's name in the native language closer to the field it describes, and added the necessary aria markup.