### PR TITLE
Add support for related pages

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -41,7 +41,7 @@ layout: default
 
   <div class="post-content">
     <p>Last Updated: {{page.updated | date: "%-d %B %Y" }}{%if page.updatemsg%} – {{page.updatemsg}}{%endif%}</p>
-    <p>Related page: Australian states (not implemented yet)</p>
+    {% if page.relatedpages %}{% for r in page.relatedpages %}<p>Related page: <a href="{{r.url}}">{{r.title}}</a></p>{% endfor %}{% endif %}
     {% for p in page.policies %}
       <h2 style="line-height: 1.5;">{% include multilang-title.html title=p.title url=p.url %}</h2>
       <div>

--- a/_policies/australia.md
+++ b/_policies/australia.md
@@ -4,7 +4,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2016-08-30
 updatemsg: Fixed broken links under the DDA, added new procurement policy announced by the Minister of Finance.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: Disability Discrimination Act 1992 (DDA)

--- a/_policies/canada.md
+++ b/_policies/canada.md
@@ -3,7 +3,9 @@ country:
   en: Canada
 updated: 2017-02-09
 updatemsg: Adding Canada to prototype from proposal document.
-# Related page: CA Provinces (https://w3c.github.io/WAI/Policy/CA-Provinces.html)
+relatedpages:
+  - title: Provincial Policies Relating to Web Accessibility
+    url: https://w3c.github.io/WAI/Policy/CA-Provinces.html
 policies:
   - title:  
       en: Canadian Human Rights Act

--- a/_policies/china.md
+++ b/_policies/china.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-02-09
 updatemsg: Adding China to prototype from proposal document.
-# Related page:
+relatedpages:
 policies:
   - title:  
       en: Voluntary Web Standard

--- a/_policies/denmark.md
+++ b/_policies/denmark.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Denmark information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Denmark A11y Law

--- a/_policies/european union.md
+++ b/_policies/european union.md
@@ -3,7 +3,7 @@ country:
   en: European Union
 updated: 2017-02-09
 updatemsg: Adding EU to prototype from proposal document.
-# Related page:
+relatedpages:
 policies:
   - title:  
       en: Web and Mobile Accessibility Directive

--- a/_policies/finland.md
+++ b/_policies/finland.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Finland information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Finland A11y Law

--- a/_policies/france.md
+++ b/_policies/france.md
@@ -4,7 +4,7 @@ country:
   fr: La France
 updated: 2016-2-17
 updatemsg: Add France to prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:  
       en: Law N° 2005-102 Article 47

--- a/_policies/germany.md
+++ b/_policies/germany.md
@@ -4,7 +4,7 @@ country:
   de: Deutschland
 updated: 2017-03-17
 updatemsg: Updated to latest information on German policy and fixed broken links
-# Related page: German states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: Act on Equal Opportunities for Disabled Persons of 2002

--- a/_policies/hong kong.md
+++ b/_policies/hong kong.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Hong Kong information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Hong Kong A11y Law

--- a/_policies/india.md
+++ b/_policies/india.md
@@ -3,7 +3,7 @@ country:
   en: India
 updated: 2017-3-24
 updatemsg: Updated information to include the new Rights of Persons with Disabilities Act passed in December 2016.
-# Related page: None
+relatedpages:
 policies:
   - title:
       en: Rights of Persons with Disabilities Act, 2016 (RPD)

--- a/_policies/ireland.md
+++ b/_policies/ireland.md
@@ -4,7 +4,7 @@ country:
   ga: Éireann
 updated: 2017-03-29
 updatemsg: Moved Ireland info into the policy prototype and updated with current info and links.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: The Disability Act, 2005

--- a/_policies/israel.md
+++ b/_policies/israel.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Israel information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Israel A11y Law

--- a/_policies/italy.md
+++ b/_policies/italy.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Italy information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Italy A11y Law

--- a/_policies/japan.md
+++ b/_policies/japan.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Japan information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Japan A11y Law

--- a/_policies/new zealand.md
+++ b/_policies/new zealand.md
@@ -4,7 +4,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for New Zealand information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First New Zealand A11y Law

--- a/_policies/portugal.md
+++ b/_policies/portugal.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Portugal information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Portugal A11y Law

--- a/_policies/spain.md
+++ b/_policies/spain.md
@@ -5,7 +5,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Spain information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Spain A11y Law

--- a/_policies/switzerland.md
+++ b/_policies/switzerland.md
@@ -7,7 +7,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for Switzerland information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First Switzerland A11y Law

--- a/_policies/united kingdom.md
+++ b/_policies/united kingdom.md
@@ -4,7 +4,7 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For United Kingdom: Schweiz, Suisse, Svizzera, Svizra
 updated: 2017-04-04
 updatemsg: Placeholder for United Kingdom information in prototype.
-# Related page: Australian states – Not sure yet how to model this, I tend to not have this
+relatedpages:
 policies:
   - title:
       en: First United Kingdom A11y Law

--- a/_policies/united states.md
+++ b/_policies/united states.md
@@ -3,7 +3,9 @@ country:
   en: United States
 updated: 2017-02-16
 updatemsg: Adding United States to prototype from proposal document.
-# Related page:
+relatedpages:
+  - title: State Policies Relating to Web Accessibility
+    url: https://www.w3.org/WAI/Policy/USA-States.html
 policies:
   - title:
       en: Section 508 of the US Rehabilitation Act of 1973, as amended


### PR DESCRIPTION
This commit adds support for related pages (on the country detail
page). To use the relatedpages feature, you need to supply one (or
more) sets of title and url data under relatedpages in the country
markdown files. Examples currently working are Canada and United States.

Resolves Issue #61 