### PR TITLE
Comment out related page because it is nonexistent

### DIFF
--- a/_policies/australia.md
+++ b/_policies/australia.md
@@ -6,9 +6,9 @@ country:
 # title_native: # Country name in the country’s language(s), comma separated. For Switzerland: Schweiz, Suisse, Svizzera, Svizra
 updated: 2016-08-30
 updatemsg: Fixed broken links under the DDA, added new procurement policy announced by the Minister of Finance.
-relatedpages:
-  - title: Policies in Australian States
-    url: http://www.w3.org/WAI/Policy/AU-States.html
+#relatedpages:
+#  - title: Policies in Australian States
+#    url: http://www.w3.org/WAI/Policy/AU-States.html
 policies:
   - title:
       en: Disability Discrimination Act 1992 (DDA)


### PR DESCRIPTION
The URL points to https://www.w3.org/WAI/Policy/AU-States.html which seems to not exist anymore.