### PR TITLE
country -> Country/Region

### DIFF
--- a/_policies/index.md
+++ b/_policies/index.md
@@ -66,7 +66,7 @@ For guidance on developing an accessibility policy for an organization, see [Dev
     </caption>
     <thead>
     <tr>
-      <th>Country</th>
+      <th>Country/Region</th>
       <th>Name</th>
       <th>Date enacted</th>
       <th>Type (Policy, law, legislation, etc.)</th>

--- a/_policies/index.md
+++ b/_policies/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Web Accessibility Laws & Policies"
-nav_title: "International Laws & Policies"
+nav_title: "Countries / Regions"
 permalink: /policies/
 order: 0
 layout: sidenav

--- a/_policies/index.md
+++ b/_policies/index.md
@@ -66,7 +66,7 @@ For guidance on developing an accessibility policy for an organization, see [Dev
     </caption>
     <thead>
     <tr>
-      <th>Country/Region</th>
+      <th>Country / Region</th>
       <th>Name</th>
       <th>Date enacted</th>
       <th>Type (Policy, law, legislation, etc.)</th>

--- a/_policies/index.md
+++ b/_policies/index.md
@@ -68,8 +68,8 @@ For guidance on developing an accessibility policy for an organization, see [Dev
     <tr>
       <th>Country / Region</th>
       <th>Name</th>
-      <th>Date enacted</th>
-      <th>Type (Policy, law, legislation, etc.)</th>
+      <th>Date Enacted</th>
+      <th>Type (policy, law, legislation, etc.)</th>
       <th>Scope</th>
       <th>Web Only</th>
       <th>WCAG Version Based On</th>

--- a/_policies/submission.md
+++ b/_policies/submission.md
@@ -35,10 +35,10 @@ Updates are delayed. We hope to have resources to make updates in early 2022. Co
   </fieldset>
 
   <fieldset>
-    <legend><h3>Country information</h3></legend>
+    <legend><h3>Country/region information</h3></legend>
     <div class="form-block-mini half">
-      <div class="form-row required"><label for="country">* Country of policy (in English): </label><br><span><input id="country" name="country" type="text" value="" required aria-required="true" ></span></div>
-      <div class="form-row"><label for="native-country">Country of policy (in native language): </label><br><span><input name="native-country" id="native-country" type="text" value="" aria-describedby="native-countrydesc"><br><span id="native-countrydesc">If known by multiple names, separate with a semicolon, e.g. Schweiz;Suisse</span></span></div>
+      <div class="form-row required"><label for="country">* Country/region of policy (in English): </label><br><span><input id="country" name="country" type="text" value="" required aria-required="true" ></span></div>
+      <div class="form-row"><label for="native-country">Country/region of policy (in native language): </label><br><span><input name="native-country" id="native-country" type="text" value="" aria-describedby="native-countrydesc"><br><span id="native-countrydesc">If known by multiple names, separate with a semicolon, e.g. Schweiz;Suisse</span></span></div>
       <div class="form-row required"><label for="state-province">State or province (in English): </label><br><span><input id="state-province" name="state-province"></span></div>
     </div>
   </fieldset>

--- a/_policies/submission.md
+++ b/_policies/submission.md
@@ -35,10 +35,10 @@ Updates are delayed. We hope to have resources to make updates in early 2022. Co
   </fieldset>
 
   <fieldset>
-    <legend><h3>Country/region information</h3></legend>
+    <legend><h3>Country/Region information</h3></legend>
     <div class="form-block-mini half">
-      <div class="form-row required"><label for="country">* Country/region of policy (in English): </label><br><span><input id="country" name="country" type="text" value="" required aria-required="true" ></span></div>
-      <div class="form-row"><label for="native-country">Country/region of policy (in native language): </label><br><span><input name="native-country" id="native-country" type="text" value="" aria-describedby="native-countrydesc"><br><span id="native-countrydesc">If known by multiple names, separate with a semicolon, e.g. Schweiz;Suisse</span></span></div>
+      <div class="form-row required"><label for="country">* Country/Region of policy (in English): </label><br><span><input id="country" name="country" type="text" value="" required aria-required="true" ></span></div>
+      <div class="form-row"><label for="native-country">Country/Region of policy (in native language): </label><br><span><input name="native-country" id="native-country" type="text" value="" aria-describedby="native-countrydesc"><br><span id="native-countrydesc">If known by multiple names, separate with a semicolon, e.g. Schweiz;Suisse</span></span></div>
       <div class="form-row required"><label for="state-province">State or province (in English): </label><br><span><input id="state-province" name="state-province"></span></div>
     </div>
   </fieldset>


### PR DESCRIPTION
**Preview : https://deploy-preview-420--wai-policies-prototype.netlify.app/policies/**

This draft pull request changes "Country" to "Country / Region" throughout the resource, including in the submission form.  It also changes the text above the left nav list from "International Laws & Policies" to "Countries / Regions".

This is relevant for several current and future listings, e.g., "European Union", and particularly important for some.
