### PR TITLE
Remove Dec 2024 "many listings" sentence; update metadata for #547

### DIFF
--- a/_policies/index.md
+++ b/_policies/index.md
@@ -9,7 +9,7 @@ layout: sidenav
 {% include box.html type="start" title="Updates" icon="default" %}
 {:/}
 
-Many listings were updated in December 2023. Near the top of each country listing is a "last updated" date.
+Near the top of each country listing is a "last updated" date.
 
 We welcome additions or corrections to these listings via the [submission form]({{ "/policies/submission/" | relative_url }}).
 

--- a/_policies/united-states.md
+++ b/_policies/united-states.md
@@ -4,8 +4,8 @@ order: 7695977.2
 title: United States
 country:
   en: United States
-last_updated: 2017-02-16
-updatemsg: Updated U.S. laws and policies. Added reference to the Revised 508 Standards.
+last_updated: 2025-01-13
+updatemsg: Added reference to Rule revising ADA Title II.
 policies:
   - title:
       en: Section 508 of the US Rehabilitation Act of 1973, as amended


### PR DESCRIPTION
This cleans up a sentence specific to last month, and updates metadata frontmatter missed in #547.