### PR TITLE
"France" country name

### DIFF
--- a/_policies/france.md
+++ b/_policies/france.md
@@ -4,7 +4,6 @@ order: 6713953
 title: France
 country:
   en: France
-  fr: La France
 last_updated: 2023-04-06
 updatemsg: Updated French accessibility laws and policies.
 relatedpages:


### PR DESCRIPTION
A French translation is not needed for "France" country name.

In a sentence, "la France", or "en France" is used in French. But when listing countries, "France" would be used in French, not "La France".